### PR TITLE
Add Citation and Zenodo metadata for release

### DIFF
--- a/.github/workflows/validate-zenodo.yaml
+++ b/.github/workflows/validate-zenodo.yaml
@@ -1,0 +1,23 @@
+name: Check zenodo metadata
+
+on:
+    push:
+        paths:
+          - '.zenodo.json'
+          - '.github/workflows/validate-zenodo.yaml'
+
+jobs:
+  check-zenodo-metadata:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install zenodraft@0.14.1
+      - name: Check .zenodo.json file
+        run: |
+          npx zenodraft metadata validate .zenodo.json 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -17,7 +17,7 @@
           "affiliation": "Duke University"
       }
     ],
-    "description": "This is the repository for the Trait2Vec model and the Character Similarity dataset. It contains the code used for training and the evaluation of Trait2Vec (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it.",
+    "description": "Code used for training the Trait2Vec model using the Character Similarity dataset, and for the evaluation of the model (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it.",
     "keywords": [
       "imageomics",
       "biology",
@@ -28,7 +28,7 @@
       "ontology",
       "phenoscape"
     ],
-    "title": "Character Similarity",
+    "title": "char-sim",
     "version": "1.0.0",
     "license": "MIT",
     "publication_date": "2025-11-05",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,40 @@
+{
+    "creators": [
+      {
+          "name": "Garcia, Juan J.",
+          "affiliation": "University of North Carolina at Chapel Hill"
+      },
+      {
+          "name": "Balhoff, James P.",
+          "affiliation": "RENCI/University of North Carolina at Chapel Hill"
+      },
+      {
+          "name": "Kar, Soumyashree",
+          "affiliation": "University of North Carolina at Chapel Hill"
+      },
+      {
+          "name": "Lapp, Hilmar",
+          "affiliation": "Duke University"
+      }
+    ],
+    "description": "This is the repository for the Trait2Vec model and the Character Similarity dataset. It contains the code used for training and the evaluation of Trait2Vec (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it.",
+    "keywords": [
+      "imageomics",
+      "biology",
+      "organism",
+      "animals",
+      "fish",
+      "traits",
+      "ontology",
+      "phenoscape"
+    ],
+    "title": "Character Similarity",
+    "version": "1.0.0",
+    "license": "MIT",
+    "publication_date": "2025-11-05",
+    "grants": [
+        {
+            "id": "021nxhr62::2118240"
+        }
+    ] 
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,7 @@
       },
       {
           "name": "Kar, Soumyashree",
-          "affiliation": "University of North Carolina at Chapel Hill"
+          "affiliation": "RENCI/University of North Carolina at Chapel Hill"
       },
       {
           "name": "Lapp, Hilmar",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,6 @@ authors:
   orcid: "https://orcid.org/0000-0002-8688-6599"
 - family-names: Kar
   given-names: "Soumyashree"
-  orcid: "https://orcid.org/<ORCID #>"
 - family-names: Lapp
   given-names: "Hilmar"
   orcid: "https://orcid.org/0000-0001-9107-0714"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ abstract: "Code used for training the Trait2Vec model using the Character Simila
 authors:
 - family-names: Garcia
   given-names: "Juan J."
-  orcid: "https://orcid.org/<ORCID #>"
+  orcid: "https://orcid.org/0009-0003-6503-2986"
 - family-names: Balhoff
   given-names: "James P."
   orcid: "https://orcid.org/0000-0002-8688-6599"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+abstract: "This is the repository for the Trait2Vec model and the Character Similarity dataset. It contains the code used for training and the evaluation of Trait2Vec (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it."
+authors:
+- family-names: Garcia
+  given-names: "Juan J."
+  orcid: "https://orcid.org/<ORCID #>"
+- family-names: Balhoff
+  given-names: "James P."
+  orcid: "https://orcid.org/0000-0002-8688-6599"
+- family-names: Kar
+  given-names: "Soumyashree"
+  orcid: "https://orcid.org/<ORCID #>"
+- family-names: Lapp
+  given-names: "Hilmar"
+  orcid: "https://orcid.org/0000-0001-9107-0714"
+cff-version: 1.2.0
+date-released: "2025-11-05"
+identifiers:
+  - description: "The GitHub release URL of tag v1.0.0."
+    type: url
+    value: "https://github.com/Imageomics/char-sim/releases/tag/v1.0.0"
+  - description: "The GitHub URL of the commit tagged with v1.0.0."
+    type: url
+    value: "https://github.com/Imageomics/char-sim/tree/<commit-hash>" # update on release
+keywords:
+  - imageomics
+  - biology
+  - organism
+  - animals
+  - fish
+  - traits
+  - ontology
+  - phenoscape
+license:
+message: "If you find this software helpful in your research, please cite both the software and our paper."
+repository-code: "https://github.com/Imageomics/char-sim"
+title: "Character Similarity"
+version: 1.0.0
+doi: <DOI from Zenodo>    # version agnostic DOI, add once generated
+type: software

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-abstract: "This is the repository for the Trait2Vec model and the Character Similarity dataset. It contains the code used for training and the evaluation of Trait2Vec (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it."
+abstract: "Code used for training the Trait2Vec model using the Character Similarity dataset, and for the evaluation of the model (testing and visualizing embeddings). Additionally, we include a collection of scripts for forming, evaluating, and visualizing the character similarity data created alongside it."
 authors:
 - family-names: Garcia
   given-names: "Juan J."

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,5 +35,5 @@ message: "If you find this software helpful in your research, please cite both t
 repository-code: "https://github.com/Imageomics/char-sim"
 title: "Character Similarity"
 version: 1.0.0
-doi: <DOI from Zenodo>    # version agnostic DOI, add once generated
+#doi: version agnostic DOI, add once generated
 type: software

--- a/README.md
+++ b/README.md
@@ -46,4 +46,11 @@ TBD
 
 ## Citation
 
-TBD
+@software{Garcia_Character_Similarity_2025,
+author = {Garcia, Juan J. and Balhoff, James P. and Kar, Soumyashree and Lapp, Hilmar},
+month = nov,
+title = {{Character Similarity}},
+url = {https://github.com/Imageomics/char-sim},
+version = {1.0.0},
+year = {2025}
+}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TBD
 @software{Garcia_Character_Similarity_2025,
 author = {Garcia, Juan J. and Balhoff, James P. and Kar, Soumyashree and Lapp, Hilmar},
 month = nov,
-title = {{Character Similarity}},
+title = {{char-sim}},
 url = {https://github.com/Imageomics/char-sim},
 version = {1.0.0},
 year = {2025}


### PR DESCRIPTION
I set up the `CITATION.cff` file and `.zenodo.json` for automatic update to Zenodo on release (note: this has **not** been turned on at Zenodo yet). Please check affiliations and ORCIDs (I didn't have @KSoumya's, so please add or remove that line in the citation file). Also, it is set up for release **today** and with a version tag of `v1.0.0`.

@hlapp, can you make sure the Zenodo integration is on or would you prefer I do it?

`README` should get the DOI after the release as well.